### PR TITLE
Perf boost

### DIFF
--- a/DistributedCacheExtensions.cs
+++ b/DistributedCacheExtensions.cs
@@ -124,8 +124,7 @@ public static class DistributedCacheExtensions
     // the old data is simply not found (and expires naturally)
     private static T Deserialize<T>(byte[] bytes)
     {
-        var payload = new Utf8JsonReader(bytes);
-        return JsonSerializer.Deserialize<T>(ref payload)!;
+        return JsonSerializer.Deserialize<T>(bytes)!;
     }
 
     private static byte[] Serialize<T>(T value)


### PR DESCRIPTION
I feel like I'm missing something here (probably), but by benchmarking the 2 versions I got these results:

| Method |     Mean |   Error |  StdDev |      P95 | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|------- |---------:|--------:|--------:|---------:|------:|--------:|-------:|----------:|------------:|
|   New | 475.4 ns | 4.00 ns | 3.74 ns | 481.6 ns |  1.00 |    0.00 | 0.0248 |     104 B |        1.00 |
|   Current | 775.4 ns | 4.48 ns | 4.19 ns | 780.6 ns |  1.63 |    0.02 | 0.0248 |     104 B |        1.00 |